### PR TITLE
Arbitrary output ROMs

### DIFF
--- a/ASSEMBLER.md
+++ b/ASSEMBLER.md
@@ -12,6 +12,9 @@ For a list of all command-line options, run
 
     ./galaxiasm --help
 
+Note that the assembler will output 2 KiB ROM files with Galaxian-appropriate
+filenames unless it’s run with the `-k` flag.
+
 
 ## Global labels and symbols
 

--- a/src/Asm/Rom.hs
+++ b/src/Asm/Rom.hs
@@ -1,31 +1,48 @@
 module Asm.Rom where
 
 import Data.Word (Word8)
-
-romSize = 2048  -- Assume 2716's
+import CommandLine (RomFormat (..))
 
 -- | Segments a binary stream of arbitrary length into batches for individual
 --   ROM files, padded to fit
 segment
   :: [Word8]     -- bytes to split
+  -> RomFormat   -- output format
+  -> String      -- base source filename
   -> [( String   -- filename for ROM
       , Int      -- starting address
       , Int      -- amount of padding added
       , [Word8]  -- ROM contents
      )]
-segment w8s = helper 0 (length w8s) w8s names
+segment w8s format basename = helper
+                                0
+                                (length w8s)
+                                (sizeForFormat format)
+                                w8s
+                                (namesForFormat format basename)
 
-names =
-  [ "galmidw.u"
-  , "galmidw.v"
-  , "galmidw.w"
-  , "galmidw.y"
-  , "7l"
-  ] ++ map (\x -> "extra_" ++ show x) [1..]
+namesForFormat :: RomFormat -> String -> [String]
+namesForFormat Default _ = [ "galmidw.u"
+                           , "galmidw.v"
+                           , "galmidw.w"
+                           , "galmidw.y"
+                           , "7l"
+                           ] ++ map (\x -> "extra_" ++ show x) [1..]
+
+namesForFormat (Kb _) basename = basename
+                                 : map
+                                     (\x -> basename ++ "_extra_" ++ show x)
+                                     [1..]
+
+sizeForFormat :: RomFormat -> Int
+sizeForFormat Default = 2048        -- assume 2716's
+sizeForFormat (Kb k)  = k * 1024
+
 
 helper
   :: Int         -- starting address
   -> Int         -- count of bytes remaining
+  -> Int         -- capacity of each ROM
   -> [Word8]     -- bytes remaining
   -> [String]    -- filename generator
   -> [( String   -- output filename
@@ -33,18 +50,19 @@ helper
       , Int      -- amount of padding added
       , [Word8]  -- ROM contents
      )]
-helper start rem w8s (name:names)
-  | rem > romSize = (name, start, 0, take romSize w8s)
-                    : helper
-                        (start + romSize)
-                        (rem - romSize)
-                        (drop romSize w8s)
-                        names
-  | otherwise     = [( name
-                     , start
-                     , romSize - (length w8s)
-                     , w8s ++ replicate (romSize - rem) 0
-                    )]
+helper start rem cap w8s (name:names)
+  | rem > cap = (name, start, 0, take cap w8s)
+                : helper
+                    (start + cap)
+                    (rem - cap)
+                    cap
+                    (drop cap w8s)
+                    names
+  | otherwise = [( name
+                  , start
+                  , cap - (length w8s)
+                  , w8s ++ replicate (cap - rem) 0
+                )]
 
 -- not actually reachable
-helper _ _ _ [] = []
+helper _ _ _ _ [] = []


### PR DESCRIPTION
This change enables the assembler to emit ROMs of arbitrary lengths (1-KiB granularity) instead of a standard Galaxian 2-KiB set. When using `-k`, the output filename/s set will correspond to the input filename.